### PR TITLE
update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.amazonaws</groupId>
 	<artifactId>aws-java-sdk-ant-tasks</artifactId>
-	<version>1.2.4-SNAPSHOT</version>
+	<version>1.2.5-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>aws-java-sdk-ant-tasks</name>
@@ -12,8 +12,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jdk.level>1.6</jdk.level>
-		<aws.sdk.version>1.9.24</aws.sdk.version>
+		<jdk.level>1.8</jdk.level>
+		<aws.sdk.version>1.11.587</aws.sdk.version>
 	</properties>
 
 	<dependencies>
@@ -61,19 +61,19 @@
 		<dependency>
 			<groupId>org.apache.ant</groupId>
 			<artifactId>ant</artifactId>
-			<version>1.9.4</version>
+			<version>1.10.9</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
+			<version>2.7</version>
 		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
 			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.1.2</version>
 				<executions>
 					<execution>
 						<id>default-jar</id>
@@ -91,7 +91,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.8.1</version>
 				<configuration>
 					<source>${jdk.level}</source>
 					<target>${jdk.level}</target>
@@ -100,7 +100,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.2</version>
+				<version>3.2.1</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -127,7 +127,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.7</version>
+				<version>1.8</version>
 				<executions>
 					<execution>
 						<phase>integration-test</phase>


### PR DESCRIPTION
Updated dependencies - it's now working until Java 17.

At least for me, without updated dependencies, S3 upload was stuck on Java 17.